### PR TITLE
Add module to capture when attaching to telemetry

### DIFF
--- a/lib/telemetry_metrics_telegraf.ex
+++ b/lib/telemetry_metrics_telegraf.ex
@@ -105,7 +105,7 @@ defmodule TelemetryMetricsTelegraf do
       :telemetry.attach(
         id,
         event,
-        &handle_event/4,
+        &__MODULE__.handle_event/4,
         {adapter, group_metrics_by_name!(metrics)}
       )
     end
@@ -129,7 +129,7 @@ defmodule TelemetryMetricsTelegraf do
     :ok
   end
 
-  defp handle_event(_event_name, measurements, metadata, {{adapter_mod, adapter_opts}, metrics}) do
+  def handle_event(_event_name, measurements, metadata, {{adapter_mod, adapter_opts}, metrics}) do
     for {measurement, metrics} <- metrics do
       {tags, fields} =
         Enum.reduce(metrics, {%{}, %{}}, fn metric, {tags, fields} ->


### PR DESCRIPTION
Telemetry emits the info when attaching without the module:

> [info] Function passed as a handler with ID {TelemetryMetricsTelegraf, [:vm, :memory], #PID<0.877.0>} is local function.
> This mean that it is either anonymous function or capture of function without module specified. That may cause performance penalty when calling such handler. For more details see note in `telemetry:attach/4` documentation.
>
> https://hexdocs.pm/telemetry/telemetry.html#attach-4